### PR TITLE
ALTER table defaults in the correct order

### DIFF
--- a/plugin-veracode-sast/src/main/resources/db/veracodesast/V004__Add_Model_Type.sql
+++ b/plugin-veracode-sast/src/main/resources/db/veracodesast/V004__Add_Model_Type.sql
@@ -1,2 +1,3 @@
-ALTER TABLE veracode_sast_apps ADD model_type varchar(255) NOT NULL;
+ALTER TABLE veracode_sast_apps ADD model_type varchar(255);
 UPDATE veracode_sast_apps SET model_type = 'Sandbox';
+ALTER TABLE veracode_sast_apps ALTER COLUMN model_type SET NOT NULL;


### PR DESCRIPTION
During DB migration, ALTER table fails when adding a constraint before setting previously null defaults.